### PR TITLE
Handle int16 fallback for CPU devices

### DIFF
--- a/src/sts/transcriber.py
+++ b/src/sts/transcriber.py
@@ -299,10 +299,12 @@ def load_model(
                 compute_type=candidate,
                 **kwargs,
             )
-        except RuntimeError as exc:  # pragma: no cover - depends on backend availability
+        except Exception as exc:  # pragma: no cover - depends on backend availability
             last_error = exc
             error_message = str(exc).lower()
-            is_int16_failure = "int16" in candidate and "int16" in error_message
+            is_int16_candidate = "int16" in candidate
+            mentions_int16_failure = "int16" in error_message
+            is_int16_failure = is_int16_candidate and mentions_int16_failure
 
             # Fall back only when the backend explicitly complains about int16
             # support. Otherwise re-raise to avoid hiding real issues.

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,0 +1,58 @@
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+def _install_stub_module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for attr_name, value in attrs.items():
+        setattr(module, attr_name, value)
+    sys.modules[name] = module
+    return module
+
+
+# Provide lightweight stubs for optional heavy dependencies to keep the test
+# environment minimal. Only the attributes referenced by ``transcriber`` during
+# import are defined.
+_install_stub_module(
+    "numpy",
+    ndarray=type("ndarray", (), {}),
+    float32=float,
+    array=lambda *args, **kwargs: None,
+    max=lambda *args, **kwargs: 0,
+    abs=abs,
+    concatenate=lambda *args, **kwargs: None,
+    mean=lambda *args, **kwargs: 0.0,
+)
+_install_stub_module("sounddevice")
+_install_stub_module("soundfile")
+_install_stub_module("ffmpeg")
+_install_stub_module("faster_whisper", WhisperModel=object)
+
+from sts import transcriber
+
+
+class DummyModel:
+    def __init__(self, model_size: str, *, compute_type: str, **kwargs):
+        # Simulate backend rejecting int16 compute type
+        if compute_type == "int16":
+            raise ValueError(
+                "Requested int16 compute type, but the target device or backend do not support efficient int16 computation."
+            )
+        self.model_size = model_size
+        self.compute_type = compute_type
+        self.kwargs = kwargs
+
+
+class LoadModelFallbackTests(unittest.TestCase):
+    def test_fallback_to_int8_when_int16_unavailable(self):
+        with patch.object(transcriber, "WhisperModel", DummyModel):
+            model = transcriber.load_model("tiny", device="cpu", compute_type="auto")
+
+        self.assertIsInstance(model, DummyModel)
+        self.assertEqual(model.compute_type, "int8")
+
+
+if __name__ == "__main__":  # pragma: no cover - test entry point
+    unittest.main()


### PR DESCRIPTION
## Summary
- update `load_model` to catch backend errors that surface as non-RuntimeError exceptions and fall back to int8 compute
- add a regression test that stubs heavy dependencies and verifies the int16 fallback path

## Testing
- PYTHONPATH=src python -m unittest discover

------
https://chatgpt.com/codex/tasks/task_e_68d6a14ea7108320b32b524e0df315e9