### PR TITLE
Add word-level transcription support with timestamped outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@
    ```
    Затем настройте Multi-Output Device в Audio MIDI Setup для одновременного вывода на динамики и BlackHole.
 
+5. Для получения покадровых таймингов слов используйте пакет [whisper-timestamped](https://github.com/linto-ai/whisper-timestamped) и его зависимости (включая `openai-whisper`). Установите их дополнительно:
+
+   ```bash
+   pip install whisper-timestamped openai-whisper
+   ```
+
 ## Использование
 
 Интерфейс предоставляется через модуль `sts.cli`. Его можно запускать командой:
@@ -83,6 +89,16 @@ python -m sts.cli --record --input-device "MacBook Pro Microphone" --output tran
 # Выбрать конкретное системное устройство
 python -m sts.cli --system-audio --input-device "BlackHole 2ch" --output transcript.txt
 ```
+
+### Тайминги каждого слова, субтитры и подсветка уверенности
+
+```bash
+python -m sts.cli --input meeting.wav --word-level --min-confidence 0.6 --output meeting.txt
+```
+
+Флаг `--word-level` включает использование whisper-timestamped: помимо основного текста будет сохранён JSON со списком слов, а также готовые субтитры в форматах SRT и VTT (`meeting.json`, `meeting.srt`, `meeting.vtt`).
+
+Параметр `--min-confidence` задаёт порог подсветки слов с низкой уверенностью: в консольном выводе и субтитрах такие слова будут выделены маркерами `⟪...⟫` вместе с числовым значением. Без флага `--word-level` порог игнорируется.
 
 ### Оптимизация под Mac M1 Pro
 

--- a/src/sts/__init__.py
+++ b/src/sts/__init__.py
@@ -1,9 +1,10 @@
 """Speech-to-text utilities built around faster-whisper."""
 
 from .transcriber import (
-    capture_audio, 
-    load_model, 
-    transcribe_audio, 
+    capture_audio,
+    load_model,
+    load_word_level_model,
+    transcribe_audio,
     extract_audio_from_video, 
     is_video_file,
     capture_system_audio,
@@ -16,6 +17,7 @@ from .transcriber import (
 __all__ = [
     "capture_audio",
     "load_model",
+    "load_word_level_model",
     "transcribe_audio",
     "extract_audio_from_video",
     "is_video_file",

--- a/src/sts/cli.py
+++ b/src/sts/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 import tempfile
 from pathlib import Path
@@ -13,6 +14,7 @@ import sounddevice as sd
 from .transcriber import (
     capture_audio,
     load_model,
+    load_word_level_model,
     transcribe_audio,
     extract_audio_from_video,
     is_video_file,
@@ -20,6 +22,10 @@ from .transcriber import (
     find_system_audio_devices,
     stream_transcribe,
     get_best_stream_profile,
+    ConfidenceMetrics,
+    TranscriptionResult,
+    TranscriptionSegment,
+    TranscriptionWord,
 )
 
 
@@ -30,6 +36,212 @@ def _parse_input_device(device: Optional[str]) -> Optional[int | str]:
         return int(device)
     except ValueError:
         return device
+
+
+def _should_highlight(word: TranscriptionWord, threshold: Optional[float]) -> bool:
+    return (
+        threshold is not None
+        and word.confidence is not None
+        and word.confidence < threshold
+    )
+
+
+def _highlight_marker(text: str) -> str:
+    return f"⟪{text}⟫"
+
+
+def _format_word_text(
+    word: TranscriptionWord,
+    threshold: Optional[float],
+    marker,
+) -> str:
+    raw_text = word.text or ""
+    if _should_highlight(word, threshold):
+        if word.confidence is not None:
+            return marker(f"{raw_text} ({word.confidence:.2f})")
+        return marker(raw_text)
+    return raw_text
+
+
+def _render_segment_text(
+    segment: TranscriptionSegment,
+    threshold: Optional[float],
+    marker=_highlight_marker,
+) -> str:
+    if not segment.words or threshold is None:
+        return segment.text
+
+    pieces: list[str] = []
+    previous_raw = ""
+
+    for word in segment.words:
+        raw_text = word.text or ""
+        if not raw_text:
+            continue
+
+        formatted = _format_word_text(word, threshold, marker)
+
+        needs_space = (
+            bool(pieces)
+            and not raw_text.startswith((
+                " ",
+                "\n",
+                "\t",
+                "-",
+                "–",
+                "—",
+                ")",
+                ",",
+                ".",
+                "!",
+                "?",
+                ";",
+                ":",
+            ))
+            and not previous_raw.endswith((
+                " ",
+                "\n",
+                "\t",
+                "-",
+                "–",
+                "—",
+                "(",
+                "«",
+                "„",
+            ))
+        )
+
+        if needs_space:
+            pieces.append(" ")
+
+        pieces.append(formatted)
+        previous_raw = raw_text
+
+    rendered = "".join(pieces).strip()
+    return rendered if rendered else segment.text
+
+
+def _result_to_json_dict(result: TranscriptionResult) -> dict:
+    payload: dict[str, object] = {
+        "text": result.text,
+        "duration": result.duration,
+        "language": result.language,
+        "segments": [],
+    }
+
+    segments: list[dict[str, object]] = []
+    for index, segment in enumerate(result.segments, start=1):
+        entry: dict[str, object] = {
+            "index": index,
+            "start": segment.start,
+            "end": segment.end,
+            "text": segment.text,
+        }
+        if segment.confidence is not None:
+            entry["confidence"] = segment.confidence
+        if segment.avg_logprob is not None:
+            entry["avg_logprob"] = segment.avg_logprob
+        if segment.compression_ratio is not None:
+            entry["compression_ratio"] = segment.compression_ratio
+        if segment.no_speech_prob is not None:
+            entry["no_speech_prob"] = segment.no_speech_prob
+        if segment.words:
+            entry["words"] = [
+                {
+                    "start": word.start,
+                    "end": word.end,
+                    "text": word.text,
+                    **(
+                        {"confidence": word.confidence}
+                        if word.confidence is not None
+                        else {}
+                    ),
+                }
+                for word in segment.words
+            ]
+        segments.append(entry)
+
+    payload["segments"] = segments
+
+    if result.words:
+        payload["words"] = [
+            {
+                "start": word.start,
+                "end": word.end,
+                "text": word.text,
+                **(
+                    {"confidence": word.confidence}
+                    if word.confidence is not None
+                    else {}
+                ),
+            }
+            for word in result.words
+        ]
+
+    if isinstance(result.word_confidence, ConfidenceMetrics):
+        payload["word_confidence"] = {
+            "average": result.word_confidence.average,
+            "minimum": result.word_confidence.minimum,
+            "maximum": result.word_confidence.maximum,
+            "count": result.word_confidence.count,
+        }
+
+    return payload
+
+
+def _format_timestamp(value: float, *, separator: str) -> str:
+    total_milliseconds = max(0, int(round(value * 1000)))
+    hours, remainder = divmod(total_milliseconds, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    seconds, milliseconds = divmod(remainder, 1_000)
+    return f"{hours:02}:{minutes:02}:{seconds:02}{separator}{milliseconds:03}"
+
+
+def _build_srt(result: TranscriptionResult, threshold: Optional[float]) -> str:
+    lines: list[str] = []
+    for index, segment in enumerate(result.segments, start=1):
+        lines.append(str(index))
+        start = _format_timestamp(segment.start, separator=",")
+        end = _format_timestamp(segment.end, separator=",")
+        lines.append(f"{start} --> {end}")
+        lines.append(_render_segment_text(segment, threshold))
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def _build_vtt(result: TranscriptionResult, threshold: Optional[float]) -> str:
+    lines: list[str] = ["WEBVTT", ""]
+    for segment in result.segments:
+        start = _format_timestamp(segment.start, separator=".")
+        end = _format_timestamp(segment.end, separator=".")
+        lines.append(f"{start} --> {end}")
+        lines.append(_render_segment_text(segment, threshold))
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def _compose_highlighted_transcript(
+    result: TranscriptionResult,
+    threshold: Optional[float],
+) -> str:
+    if threshold is None:
+        return result.text
+
+    parts = [
+        _render_segment_text(segment, threshold)
+        for segment in result.segments
+    ]
+    return "\n".join(filter(None, parts))
+
+
+def _print_confidence_summary(summary: Optional[ConfidenceMetrics]) -> None:
+    if not summary:
+        return
+
+    print(
+        "Средняя уверенность слов: "
+        f"{summary.average:.2f} (мин: {summary.minimum:.2f}, макс: {summary.maximum:.2f}, всего: {summary.count})"
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -122,7 +334,10 @@ def build_parser() -> argparse.ArgumentParser:
         "--output",
         type=Path,
         default=None,
-        help="Файл для сохранения результата распознавания (текстовый формат).",
+        help=(
+            "Файл для сохранения результата распознавания. В word-level режиме дополнительно "
+            "создаются JSON/SRT/VTT с таймкодами слов."
+        ),
     )
     parser.add_argument(
         "--beam-size",
@@ -145,6 +360,22 @@ def build_parser() -> argparse.ArgumentParser:
         "--no-vad",
         action="store_true",
         help="Отключить VAD-фильтр быстрее-шёпота (по умолчанию включён).",
+    )
+    parser.add_argument(
+        "--word-level",
+        action="store_true",
+        help=(
+            "Использовать whisper-timestamped для покадровой разбивки и таймингов слов."
+        ),
+    )
+    parser.add_argument(
+        "--min-confidence",
+        type=float,
+        default=None,
+        help=(
+            "Минимальная уверенность слова для подсветки в выводе и субтитрах "
+            "(работает с --word-level)."
+        ),
     )
     return parser
 
@@ -218,10 +449,23 @@ def main(argv: Optional[list[str]] = None) -> None:
     args = parser.parse_args(argv)
 
     _maybe_list_devices(args.list_devices)
-    
+
+    if args.min_confidence is not None and not 0.0 <= args.min_confidence <= 1.0:
+        parser.error("--min-confidence ожидает значение в диапазоне от 0 до 1.")
+
+    if args.min_confidence is not None and not args.word_level:
+        print(
+            "⚠️  --min-confidence применяется только вместе с --word-level, параметр будет проигнорирован.",
+            file=sys.stderr,
+        )
+        args.min_confidence = None
+
     # Проверяем, что выбран один из источников
     if not any([args.input, args.record, args.system_audio, args.web, args.stream]):
         parser.error("Необходимо выбрать один из: --input, --record, --system-audio, --web, или --stream")
+
+    if args.word_level and (args.web or args.stream):
+        parser.error("Режим --word-level доступен только для офлайн транскрибации файлов или записей.")
     
     # Запуск веб-интерфейса
     if args.web:
@@ -307,6 +551,20 @@ def main(argv: Optional[list[str]] = None) -> None:
             )
             raise SystemExit(1)
 
+        timestamped_model = None
+        if args.word_level:
+            try:
+                timestamped_model = load_word_level_model(
+                    model_name,
+                    device=args.device,
+                )
+            except ImportError as exc:
+                print(f"Не удалось загрузить whisper-timestamped: {exc}", file=sys.stderr)
+                raise SystemExit(1)
+            except Exception as exc:
+                print(f"Ошибка инициализации whisper-timestamped: {exc}", file=sys.stderr)
+                raise SystemExit(1)
+
         result = transcribe_audio(
             model,
             audio_path,
@@ -314,24 +572,58 @@ def main(argv: Optional[list[str]] = None) -> None:
             language=requested_language,
             temperature=args.temperature,
             vad_filter=not args.no_vad,
+            word_level=args.word_level,
+            timestamped_model=timestamped_model,
+            timestamped_model_name=model_name,
+            timestamped_device=args.device,
         )
 
         print("\n=== Результат распознавания ===")
         if result.language:
             print(f"Определённый язык: {result.language}")
         print(f"Длительность: {result.duration:.2f} с")
+        highlight_threshold = args.min_confidence if args.word_level else None
+        if result.word_confidence:
+            _print_confidence_summary(result.word_confidence)
+        if args.word_level and highlight_threshold is not None:
+            print(f"Порог подсветки: {highlight_threshold:.2f}")
         print()
 
         for idx, segment in enumerate(result.segments, start=1):
-            print(f"[{idx:03d}] {segment.start:7.2f} — {segment.end:7.2f}: {segment.text}")
+            segment_text = _render_segment_text(segment, highlight_threshold)
+            print(f"[{idx:03d}] {segment.start:7.2f} — {segment.end:7.2f}: {segment_text}")
 
         print("\nИтоговый текст:\n")
-        print(result.text)
+        final_text = (
+            _compose_highlighted_transcript(result, highlight_threshold)
+            if args.word_level
+            else result.text
+        )
+        print(final_text)
 
         if args.output:
             args.output.parent.mkdir(parents=True, exist_ok=True)
-            args.output.write_text(result.text, encoding="utf-8")
+            text_payload = final_text if args.word_level else result.text
+            args.output.write_text(text_payload, encoding="utf-8")
             print(f"\nТранскрипция сохранена в {args.output}")
+
+            if args.word_level:
+                json_path = args.output.with_suffix(".json")
+                srt_path = args.output.with_suffix(".srt")
+                vtt_path = args.output.with_suffix(".vtt")
+
+                json_payload = _result_to_json_dict(result)
+                json_path.write_text(
+                    json.dumps(json_payload, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+                srt_path.write_text(_build_srt(result, highlight_threshold), encoding="utf-8")
+                vtt_path.write_text(_build_vtt(result, highlight_threshold), encoding="utf-8")
+
+                print(
+                    "Дополнительно сохранены файлы: "
+                    f"{json_path.name}, {srt_path.name}, {vtt_path.name}"
+                )
     finally:
         if is_temp_file and audio_path and audio_path.exists():
             audio_path.unlink()

--- a/src/sts/transcriber.py
+++ b/src/sts/transcriber.py
@@ -9,7 +9,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Deque, List, Optional, Sequence, Set, Union
+from typing import Any, Deque, Dict, Iterable, List, Optional, Sequence, Set, Union
 
 import numpy as np
 import sounddevice as sd
@@ -21,6 +21,16 @@ try:
     HAS_FFMPEG = True
 except ImportError:
     HAS_FFMPEG = False
+
+# ``whisper_timestamped`` pulls in optional heavy dependencies (openai-whisper, torch).
+# Import lazily so that basic usage keeps working even when the package is not
+# installed. The attribute resolution happens inside ``_transcribe_with_timestamped``.
+try:  # pragma: no cover - optional dependency
+    import whisper_timestamped  # type: ignore
+    HAS_WHISPER_TIMESTAMPED = True
+except Exception:  # pragma: no cover - optional dependency
+    whisper_timestamped = None  # type: ignore[assignment]
+    HAS_WHISPER_TIMESTAMPED = False
 
 
 @dataclass
@@ -56,6 +66,31 @@ class TranscriptionSegment:
     start: float
     end: float
     text: str
+    confidence: Optional[float] = None
+    avg_logprob: Optional[float] = None
+    compression_ratio: Optional[float] = None
+    no_speech_prob: Optional[float] = None
+    words: Optional[List["TranscriptionWord"]] = None
+
+
+@dataclass
+class TranscriptionWord:
+    """Word-level timing and confidence information."""
+
+    start: float
+    end: float
+    text: str
+    confidence: Optional[float] = None
+
+
+@dataclass
+class ConfidenceMetrics:
+    """Aggregated confidence statistics for the transcription."""
+
+    average: float
+    minimum: float
+    maximum: float
+    count: int
 
 
 @dataclass
@@ -66,6 +101,187 @@ class TranscriptionResult:
     segments: List[TranscriptionSegment]
     duration: float
     language: Optional[str]
+    words: Optional[List[TranscriptionWord]] = None
+    word_confidence: Optional[ConfidenceMetrics] = None
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    """Convert arbitrary numeric values to float, returning None on failure."""
+
+    if value is None:
+        return None
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _compute_confidence_metrics(words: Iterable[TranscriptionWord]) -> Optional[ConfidenceMetrics]:
+    """Aggregate confidence statistics for a collection of words."""
+
+    confidences = [confidence for word in words if (confidence := word.confidence) is not None]
+    if not confidences:
+        return None
+
+    total = sum(confidences)
+    count = len(confidences)
+    return ConfidenceMetrics(
+        average=total / count,
+        minimum=min(confidences),
+        maximum=max(confidences),
+        count=count,
+    )
+
+
+def load_word_level_model(
+    name: str,
+    *,
+    device: Optional[str] = None,
+    backend: str = "openai-whisper",
+    download_root: Optional[str] = None,
+    in_memory: bool = False,
+):  # pragma: no cover - depends on optional dependency
+    """Load a Whisper model compatible with whisper-timestamped."""
+
+    if not HAS_WHISPER_TIMESTAMPED:
+        raise ImportError(
+            "Пакет whisper-timestamped не установлен. Установите его и зависимости (openai-whisper)."
+        )
+
+    try:
+        load_fn = getattr(whisper_timestamped, "load_model")  # type: ignore[attr-defined]
+    except AttributeError:
+        from whisper_timestamped.transcribe import load_model as load_fn  # type: ignore
+
+    kwargs: Dict[str, Any] = {"backend": backend, "in_memory": in_memory}
+    if device is not None:
+        kwargs["device"] = device
+    if download_root is not None:
+        kwargs["download_root"] = download_root
+
+    return load_fn(name, **kwargs)
+
+
+def _map_timestamped_segments(raw_segments: Iterable[Dict[str, Any]]) -> tuple[List[TranscriptionSegment], List[TranscriptionWord]]:
+    """Convert whisper-timestamped segments into dataclass-friendly structures."""
+
+    segments: List[TranscriptionSegment] = []
+    words: List[TranscriptionWord] = []
+
+    for raw_segment in raw_segments:
+        raw_words = raw_segment.get("words") or []
+        segment_words: List[TranscriptionWord] = []
+        for raw_word in raw_words:
+            word = TranscriptionWord(
+                start=_safe_float(raw_word.get("start")) or 0.0,
+                end=_safe_float(raw_word.get("end")) or 0.0,
+                text=str(raw_word.get("text", "")),
+                confidence=(
+                    _safe_float(
+                        raw_word.get("confidence", raw_word.get("probability"))
+                    )
+                ),
+            )
+            segment_words.append(word)
+            words.append(word)
+
+        segment = TranscriptionSegment(
+            start=_safe_float(raw_segment.get("start")) or 0.0,
+            end=_safe_float(raw_segment.get("end")) or 0.0,
+            text=str(raw_segment.get("text", "")).strip(),
+            confidence=_safe_float(raw_segment.get("confidence")),
+            avg_logprob=_safe_float(raw_segment.get("avg_logprob")),
+            compression_ratio=_safe_float(raw_segment.get("compression_ratio")),
+            no_speech_prob=_safe_float(raw_segment.get("no_speech_prob")),
+            words=segment_words or None,
+        )
+        segments.append(segment)
+
+    return segments, words
+
+
+def _transcribe_with_timestamped(
+    audio_input: Union[str, np.ndarray],
+    *,
+    language: Optional[str],
+    beam_size: int,
+    temperature: float,
+    vad_filter: bool,
+    compression_ratio_threshold: float,
+    log_prob_threshold: float,
+    no_speech_threshold: float,
+    condition_on_previous_text: bool,
+    timestamped_model: Optional[Any],
+    timestamped_model_name: Optional[str],
+    timestamped_device: Optional[str],
+    timestamped_options: Optional[Dict[str, Any]],
+) -> TranscriptionResult:
+    """Run whisper-timestamped and map the response into ``TranscriptionResult``."""
+
+    if not HAS_WHISPER_TIMESTAMPED:
+        raise ImportError(
+            "Режим поминутной разбивки по словам требует whisper-timestamped и openai-whisper."
+        )
+
+    try:
+        transcribe_fn = getattr(whisper_timestamped, "transcribe_timestamped")  # type: ignore[attr-defined]
+    except AttributeError as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "Функция transcribe_timestamped недоступна в установленной версии whisper-timestamped."
+        ) from exc
+
+    active_model = timestamped_model
+    if active_model is None:
+        if not timestamped_model_name:
+            raise ValueError(
+                "Не указан параметр timestamped_model_name для режима word-level."
+            )
+        active_model = load_word_level_model(
+            timestamped_model_name,
+            device=timestamped_device,
+        )
+
+    kwargs: Dict[str, Any] = {
+        "language": language,
+        "beam_size": beam_size,
+        "temperature": temperature,
+        "compression_ratio_threshold": compression_ratio_threshold,
+        "logprob_threshold": log_prob_threshold,
+        "no_speech_threshold": no_speech_threshold,
+        "condition_on_previous_text": condition_on_previous_text,
+        "vad": vad_filter,
+    }
+
+    if timestamped_options:
+        kwargs.update(timestamped_options)
+
+    # Remove ``None`` values so that whisper-timestamped can fall back to defaults.
+    clean_kwargs = {key: value for key, value in kwargs.items() if value is not None}
+
+    raw_result = transcribe_fn(active_model, audio_input, **clean_kwargs)
+
+    raw_segments = raw_result.get("segments") or []
+    segments, words = _map_timestamped_segments(raw_segments)
+
+    duration = _safe_float(raw_result.get("duration"))
+    if (duration is None) and segments:
+        duration = max((segment.end for segment in segments), default=0.0)
+    duration = duration or 0.0
+
+    text = str(raw_result.get("text", "")).strip()
+    language_code = raw_result.get("language")
+
+    confidence_metrics = _compute_confidence_metrics(words)
+
+    return TranscriptionResult(
+        text=text,
+        segments=segments,
+        duration=duration,
+        language=str(language_code) if language_code else None,
+        words=words or None,
+        word_confidence=confidence_metrics,
+    )
 
 
 def _calculate_overlap(previous: str, current: str, *, max_overlap_chars: int = 160) -> int:
@@ -382,6 +598,11 @@ def transcribe_audio(
     log_prob_threshold: float = -1.0,
     no_speech_threshold: float = 0.6,
     condition_on_previous_text: bool = True,
+    word_level: bool = False,
+    timestamped_model: Optional[Any] = None,
+    timestamped_model_name: Optional[str] = None,
+    timestamped_device: Optional[str] = None,
+    timestamped_options: Optional[Dict[str, Any]] = None,
 ) -> TranscriptionResult:
     """Transcribe an audio file and aggregate the model output."""
 
@@ -389,6 +610,23 @@ def transcribe_audio(
         audio_input: Union[str, np.ndarray] = str(audio_source)
     else:
         audio_input = audio_source
+
+    if word_level:
+        return _transcribe_with_timestamped(
+            audio_input,
+            language=language,
+            beam_size=beam_size,
+            temperature=temperature,
+            vad_filter=vad_filter,
+            compression_ratio_threshold=compression_ratio_threshold,
+            log_prob_threshold=log_prob_threshold,
+            no_speech_threshold=no_speech_threshold,
+            condition_on_previous_text=condition_on_previous_text,
+            timestamped_model=timestamped_model,
+            timestamped_model_name=timestamped_model_name,
+            timestamped_device=timestamped_device,
+            timestamped_options=timestamped_options,
+        )
 
     segment_iter, info = model.transcribe(
         audio_input,
@@ -418,6 +656,10 @@ def transcribe_audio(
                 start=segment.start,
                 end=segment.end,
                 text=text,
+                confidence=getattr(segment, "confidence", None),
+                avg_logprob=getattr(segment, "avg_logprob", None),
+                compression_ratio=getattr(segment, "compression_ratio", None),
+                no_speech_prob=getattr(segment, "no_speech_prob", None),
             )
         )
         if text:


### PR DESCRIPTION
## Summary
- extend transcription dataclasses to capture word-level data and integrate whisper-timestamped when requested
- update the CLI with word-level and confidence options, formatted exports (JSON/SRT/VTT), and highlighting utilities
- document the new workflow and export formats in the README and surface the loader through the package init

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6bc5eeee08320ab21c2683ad65d84