### PR TITLE
Add Silero-based VAC controller to streaming transcriber

### DIFF
--- a/src/sts/cli.py
+++ b/src/sts/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import sys
 import tempfile
+from dataclasses import replace
 from pathlib import Path
 from typing import Optional
 
@@ -146,6 +147,38 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Отключить VAD-фильтр быстрее-шёпота (по умолчанию включён).",
     )
+    vac_group = parser.add_mutually_exclusive_group()
+    vac_group.add_argument(
+        "--vac",
+        dest="vac",
+        action="store_true",
+        help="Включить Silero VAC перед инференсом в потоковом режиме.",
+    )
+    vac_group.add_argument(
+        "--no-vac",
+        dest="vac",
+        action="store_false",
+        help="Отключить Silero VAC и использовать энергетику для сегментации.",
+    )
+    parser.set_defaults(vac=True)
+    parser.add_argument(
+        "--vac-window",
+        type=float,
+        default=None,
+        help="Длительность окна VAC в секундах для агрегирования аудиофреймов.",
+    )
+    parser.add_argument(
+        "--vac-min-silence",
+        type=float,
+        default=None,
+        help="Минимальная длительность паузы (сек), после которой сегмент считается завершённым.",
+    )
+    parser.add_argument(
+        "--vac-pad",
+        type=float,
+        default=None,
+        help="Запас (сек) по краям сегмента речи для VAC.",
+    )
     return parser
 
 
@@ -245,6 +278,15 @@ def main(argv: Optional[list[str]] = None) -> None:
                 model_name = multilingual_candidate
 
         profile = get_best_stream_profile()
+        profile = replace(
+            profile,
+            use_vac=args.vac,
+            vac_window=args.vac_window if args.vac_window is not None else profile.vac_window,
+            vac_min_silence=(
+                args.vac_min_silence if args.vac_min_silence is not None else profile.vac_min_silence
+            ),
+            vac_speech_pad=args.vac_pad if args.vac_pad is not None else profile.vac_speech_pad,
+        )
         cpu_threads = args.cpu_threads if args.cpu_threads is not None else profile.cpu_threads
 
         model = load_model(

--- a/src/sts/transcriber.py
+++ b/src/sts/transcriber.py
@@ -22,6 +22,7 @@ try:
 except ImportError:
     HAS_FFMPEG = False
 
+from .vac import VACConfig, VoiceActivityController
 
 @dataclass
 class StreamProfile:
@@ -35,6 +36,10 @@ class StreamProfile:
     temperature: float
     use_threading: bool
     cpu_threads: Optional[int]
+    use_vac: bool
+    vac_window: float
+    vac_min_silence: float
+    vac_speech_pad: float
 
 
 BEST_STREAM_PROFILE = StreamProfile(
@@ -46,6 +51,10 @@ BEST_STREAM_PROFILE = StreamProfile(
     temperature=0.0,
     use_threading=True,
     cpu_threads=4,
+    use_vac=True,
+    vac_window=1.8,
+    vac_min_silence=0.25,
+    vac_speech_pad=0.12,
 )
 
 
@@ -592,12 +601,15 @@ class StreamTranscriber:
         self.silence_threshold = 0.0015
         self._emitted_history: Deque[str] = deque(maxlen=12)
         self._cumulative_text = ""
+        self._vac_controller: Optional[VoiceActivityController] = None
 
     def start(self, model: WhisperModel, device: Optional[int | str] = None,
               samplerate: int = 16_000, channels: int = 2, chunk_duration: float = 5.0,
               language: Optional[str] = None, beam_size: int = 5, vad_filter: bool = True,
               overlap_ratio: float = 0.25, temperature: float = 0.0,
-              use_threading: bool = True, callback=None):
+              use_threading: bool = True, callback=None,
+              use_vac: bool = True, vac_window: float = 1.8,
+              vac_min_silence: float = 0.25, vac_speech_pad: float = 0.12):
         """Start streaming transcription."""
 
         if self.recording:
@@ -614,160 +626,103 @@ class StreamTranscriber:
             else:
                 print("Системное аудиоустройство не найдено.")
         
-        self.audio_queue = queue.Queue(maxsize=100)  # Большая очередь
+        self.audio_queue = queue.Queue(maxsize=100)  # Очередь готовых сегментов
         self.result_queue = queue.Queue()
         self.recording = True
         self._emitted_history.clear()
         self._cumulative_text = ""
 
+        vac_config = VACConfig(
+            samplerate=samplerate,
+            chunk_duration=chunk_duration,
+            overlap_ratio=overlap_ratio,
+            silence_threshold=self.silence_threshold,
+            window_duration=vac_window,
+            min_silence_duration=vac_min_silence,
+            speech_pad=vac_speech_pad,
+            enabled=use_vac,
+        )
+        self._vac_controller = VoiceActivityController(vac_config)
+        if use_vac and self._vac_controller.load_error:
+            print(
+                f"Внимание: контроллер голосовой активности недоступен ({self._vac_controller.load_error}). "
+                "Используется детекция тишины по RMS.",
+                file=sys.stderr,
+            )
+
         # Создаем пул потоков для обработки
         import concurrent.futures
+
         self.thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=self.max_threads)
-        
-        def audio_callback(indata: np.ndarray, frames: int, time, status) -> None:  # type: ignore[override]
+
+        def audio_callback(indata: np.ndarray, frames: int, time_info, status) -> None:  # type: ignore[override]
             if status:
                 print(status, file=sys.stderr)
-            if self.recording:
-                self.audio_queue.put(indata.copy())
-        
-        min_chunk_duration = max(chunk_duration, 0.4)
-        target_chunk_samples = max(int(min_chunk_duration * samplerate), samplerate // 2)
+            if not self.recording or self._vac_controller is None:
+                return
+
+            frame_copy = indata.copy()
+            for chunk in self._vac_controller.push(frame_copy):
+                if chunk.size:
+                    self.audio_queue.put(chunk)
+
+        def process_chunk(chunk_array: np.ndarray, emitted_time: float) -> None:
+            try:
+                if not chunk_array.size:
+                    return
+
+                if self._vac_controller and self._vac_controller.should_skip_silence(chunk_array):
+                    return
+
+                audio_array = _prepare_audio_array(chunk_array)
+                if not audio_array.size:
+                    return
+
+                result = transcribe_audio(
+                    model,
+                    audio_array,
+                    language=language,
+                    beam_size=beam_size,
+                    temperature=temperature,
+                    vad_filter=vad_filter,
+                    compression_ratio_threshold=1.8,
+                    condition_on_previous_text=False,
+                )
+
+                addition = _merge_with_history(result.text, self._emitted_history)
+
+                if callback and addition and self.recording:
+                    self._cumulative_text = f"{self._cumulative_text} {addition}".strip()
+                    callback({
+                        'text': addition,
+                        'language': result.language,
+                        'timestamp': emitted_time,
+                        'duration': result.duration,
+                    })
+
+            except Exception as e:
+                if self.recording:
+                    print(f"Ошибка: {e}")
+
+        def submit_chunk(chunk_array: np.ndarray, emitted_time: float) -> None:
+            if use_threading:
+                self.thread_pool.submit(process_chunk, chunk_array, emitted_time)
+            else:
+                process_chunk(chunk_array, emitted_time)
 
         def process_audio_chunks():
-            """Process audio chunks in separate thread."""
-            chunk_data: List[np.ndarray] = []
-            chunk_start_time = time.time()
-            chunk_samples = 0
+            """Process ready audio chunks in a separate thread."""
 
             while self.recording or not self.audio_queue.empty():
                 try:
-                    # Получаем аудиоданные с таймаутом
                     audio_chunk = self.audio_queue.get(timeout=0.1)
-                    chunk_data.append(audio_chunk)
-                    chunk_samples += len(audio_chunk)
-
-                    # Проверяем, прошло ли достаточно времени для обработки чанка
-                    current_time = time.time()
-                    duration_ready = current_time - chunk_start_time >= chunk_duration
-                    samples_ready = chunk_samples >= target_chunk_samples
-
-                    if (duration_ready or samples_ready) and chunk_data:
-                        combined_chunk = np.concatenate(chunk_data, axis=0)
-                        processed_samples = combined_chunk.shape[0]
-
-                        if processed_samples and self.recording:
-                            def process_chunk_instant(chunk_array=combined_chunk, emitted_time=current_time):
-                                try:
-                                    if not chunk_array.size:
-                                        return
-
-                                    # Проверяем наличие полезного сигнала, чтобы не тратить время на тишину
-                                    rms = math.sqrt(float(np.mean(chunk_array**2)))
-                                    if rms < self.silence_threshold:
-                                        return
-
-                                    audio_array = _prepare_audio_array(chunk_array)
-                                    if not audio_array.size:
-                                        return
-
-                                    result = transcribe_audio(
-                                        model,
-                                        audio_array,
-                                        language=language,
-                                        beam_size=beam_size,
-                                        temperature=temperature,
-                                        vad_filter=vad_filter,
-                                        compression_ratio_threshold=1.8,
-                                        condition_on_previous_text=False,
-                                    )
-
-                                    addition = _merge_with_history(result.text, self._emitted_history)
-
-                                    if callback and addition and self.recording:
-                                        self._cumulative_text = f"{self._cumulative_text} {addition}".strip()
-                                        callback({
-                                            'text': addition,
-                                            'language': result.language,
-                                            'timestamp': emitted_time,
-                                            'duration': result.duration,
-                                        })
-
-                                except Exception as e:
-                                    if self.recording:
-                                        print(f"Ошибка: {e}")
-
-                            if use_threading:
-                                self.thread_pool.submit(process_chunk_instant)
-                            else:
-                                process_chunk_instant()
-
-                        if overlap_ratio > 0 and processed_samples > 0:
-                            overlap_samples = int(processed_samples * overlap_ratio)
-                            if overlap_samples > 0:
-                                chunk_data = [combined_chunk[-overlap_samples:]]
-                                chunk_samples = overlap_samples
-                            else:
-                                chunk_data = []
-                                chunk_samples = 0
-                        else:
-                            chunk_data = []
-                            chunk_samples = 0
-
-                        chunk_start_time = current_time
-
                 except queue.Empty:
                     continue
-                except Exception as e:
-                    if self.recording:
-                        print(f"Ошибка обработки аудио: {e}")
+
+                if audio_chunk is None:
                     break
 
-            if chunk_data and chunk_samples:
-                combined_chunk = np.concatenate(chunk_data, axis=0)
-
-                def flush_chunk(chunk_array=combined_chunk):
-                    try:
-                        if not chunk_array.size:
-                            return
-
-                        rms = math.sqrt(float(np.mean(chunk_array**2)))
-                        if rms < self.silence_threshold:
-                            return
-
-                        audio_array = _prepare_audio_array(chunk_array)
-                        if not audio_array.size:
-                            return
-
-                        result = transcribe_audio(
-                            model,
-                            audio_array,
-                            language=language,
-                            beam_size=beam_size,
-                            temperature=temperature,
-                            vad_filter=vad_filter,
-                            compression_ratio_threshold=1.8,
-                            condition_on_previous_text=False,
-                        )
-
-                        addition = _merge_with_history(result.text, self._emitted_history)
-
-                        if callback and addition:
-                            self._cumulative_text = f"{self._cumulative_text} {addition}".strip()
-                            callback({
-                                'text': addition,
-                                'language': result.language,
-                                'timestamp': time.time(),
-                                'duration': result.duration,
-                            })
-
-                    except Exception as e:
-                        print(f"Ошибка: {e}")
-
-                if use_threading:
-                    self.thread_pool.submit(flush_chunk)
-                else:
-                    flush_chunk()
-        
+                submit_chunk(audio_chunk, time.time())
         print("Начинаю потоковую транскрибацию.")
         
         # Запускаем обработку аудио в отдельном потоке
@@ -803,7 +758,16 @@ class StreamTranscriber:
             self.audio_stream.stop()
             self.audio_stream.close()
             self.audio_stream = None
-        
+
+        if self.audio_queue is not None and self._vac_controller is not None:
+            try:
+                for chunk in self._vac_controller.finalize():
+                    if chunk.size:
+                        self.audio_queue.put(chunk)
+                self.audio_queue.put(None)
+            except Exception as e:
+                print(f"Ошибка завершения VAC: {e}")
+
         # Останавливаем пул потоков
         if hasattr(self, 'thread_pool'):
             self.thread_pool.shutdown(wait=False)
@@ -849,6 +813,10 @@ def stream_transcribe(
         temperature=active_profile.temperature,
         use_threading=active_profile.use_threading,
         callback=callback,
+        use_vac=active_profile.use_vac,
+        vac_window=active_profile.vac_window,
+        vac_min_silence=active_profile.vac_min_silence,
+        vac_speech_pad=active_profile.vac_speech_pad,
     ):
         return
 

--- a/src/sts/vac.py
+++ b/src/sts/vac.py
@@ -1,0 +1,281 @@
+"""Voice activity controller for streaming transcription."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import List, Optional
+
+import numpy as np
+
+
+@dataclass
+class VACConfig:
+    """Configuration for the voice activity controller."""
+
+    samplerate: int
+    chunk_duration: float
+    overlap_ratio: float
+    silence_threshold: float
+    window_duration: float
+    min_silence_duration: float
+    speech_pad: float
+    enabled: bool
+
+
+class VoiceActivityController:
+    """Aggregate audio frames and emit speech segments using optional VAD."""
+
+    def __init__(self, config: VACConfig):
+        self.config = config
+        self._request_vac = config.enabled
+        self._vad_model = None
+        self._torch = None
+        self._get_speech_timestamps = None
+        self._load_error: Optional[str] = None
+
+        if self._request_vac and config.samplerate not in (8000, 16000):
+            self._load_error = "VAC поддерживает только 8 или 16 кГц"
+            self._request_vac = False
+
+        if self._request_vac:
+            self._initialize_vad()
+
+        self.using_vac = self._request_vac and self._vad_model is not None
+
+        # Buffers for VAC path
+        self._residual_mono = np.zeros(0, dtype=np.float32)
+        self._residual_multi = np.zeros((0, 1), dtype=np.float32)
+        self._vad_buffer_mono: List[np.ndarray] = []
+        self._vad_buffer_multi: List[np.ndarray] = []
+        self._vad_buffer_samples = 0
+
+        # Buffers for RMS fallback path
+        self._chunk_buffer: List[np.ndarray] = []
+        self._chunk_samples = 0
+        self._chunk_start_time: Optional[float] = None
+        self._overlap_tail: Optional[np.ndarray] = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @property
+    def load_error(self) -> Optional[str]:
+        return self._load_error
+
+    def push(self, frame: np.ndarray) -> List[np.ndarray]:
+        """Consume raw audio frame and return speech-ready chunks."""
+
+        if not frame.size:
+            return []
+
+        if self.using_vac:
+            return self._push_with_vad(frame)
+
+        return self._push_without_vad(frame)
+
+    def finalize(self) -> List[np.ndarray]:
+        """Flush pending data when recording stops."""
+
+        if self.using_vac:
+            return self._flush_vad(final=True)
+
+        pending = []
+        if self._chunk_buffer:
+            combined = np.concatenate(self._chunk_buffer, axis=0)
+            pending.append(combined)
+            self._chunk_buffer = []
+            self._chunk_samples = 0
+            self._chunk_start_time = None
+
+        self._overlap_tail = None
+
+        return pending
+
+    def should_skip_silence(self, chunk: np.ndarray) -> bool:
+        """Return True if chunk should be dropped as silence in fallback mode."""
+
+        if self.using_vac:
+            return False
+
+        if not chunk.size:
+            return True
+
+        rms = float(np.sqrt(np.mean(np.square(chunk))))
+        return rms < self.config.silence_threshold
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _initialize_vad(self) -> None:
+        try:
+            import torch
+        except ImportError as exc:  # pragma: no cover - optional dependency
+            self._load_error = f"не удалось импортировать torch: {exc}"
+            return
+
+        try:
+            model, utils = torch.hub.load(
+                "snakers4/silero-vad",
+                "silero_vad",
+                force_reload=False,
+                trust_repo=True,
+            )
+        except Exception as exc:  # pragma: no cover - optional dependency
+            self._load_error = f"ошибка загрузки Silero VAD: {exc}"
+            return
+
+        # utils import torchaudio; if it's unavailable we gracefully fall back
+        required = ["get_speech_timestamps"]
+        for name in required:
+            if name not in utils:
+                self._load_error = "Silero utils не предоставили get_speech_timestamps"
+                return
+
+        self._vad_model = model
+        self._torch = torch
+        self._get_speech_timestamps = utils["get_speech_timestamps"]
+
+        try:
+            self._vad_model.to("cpu")
+            self._vad_model.reset_states()
+        except Exception:
+            # Model might not expose reset_states for ONNX variant – ignore
+            pass
+
+    # --------------------------- VAC path -----------------------------
+    def _push_with_vad(self, frame: np.ndarray) -> List[np.ndarray]:
+        mono_frame, multi_frame = self._split_frame(frame)
+
+        self._vad_buffer_mono.append(mono_frame)
+        self._vad_buffer_multi.append(multi_frame)
+        self._vad_buffer_samples += len(mono_frame)
+
+        window_samples = max(int(self.config.window_duration * self.config.samplerate), 1)
+        if self._vad_buffer_samples < window_samples:
+            return []
+
+        return self._flush_vad()
+
+    def _flush_vad(self, final: bool = False) -> List[np.ndarray]:
+        if not (self._vad_buffer_mono or self._residual_mono.size):
+            return []
+
+        mono_segments = []
+        multi_segments = []
+
+        if self._residual_mono.size:
+            mono_segments.append(self._residual_mono)
+            multi_segments.append(self._residual_multi)
+
+        mono_segments.extend(self._vad_buffer_mono)
+        multi_segments.extend(self._vad_buffer_multi)
+
+        mono_window = np.concatenate(mono_segments, axis=0).astype(np.float32, copy=False)
+        multi_window = np.concatenate(multi_segments, axis=0).astype(np.float32, copy=False)
+
+        self._vad_buffer_mono = []
+        self._vad_buffer_multi = []
+        self._vad_buffer_samples = 0
+
+        chunks = self._run_vad(mono_window, multi_window)
+
+        if final:
+            self._residual_mono = np.zeros(0, dtype=np.float32)
+            self._residual_multi = np.zeros((0, multi_window.shape[1]), dtype=np.float32)
+        else:
+            keep_tail = max(int(self.config.speech_pad * self.config.samplerate), 0)
+            tail_start = max(len(mono_window) - keep_tail, 0)
+            self._residual_mono = mono_window[tail_start:]
+            self._residual_multi = multi_window[tail_start:]
+
+        return chunks
+
+    def _run_vad(self, mono_window: np.ndarray, multi_window: np.ndarray) -> List[np.ndarray]:
+        if not self._get_speech_timestamps or self._vad_model is None:
+            return []
+
+        tensor = self._torch.from_numpy(mono_window)
+        try:
+            timestamps = self._get_speech_timestamps(
+                tensor,
+                self._vad_model,
+                threshold=0.5,
+                sampling_rate=self.config.samplerate,
+                min_speech_duration_ms=int(self.config.min_silence_duration * 1000),
+                min_silence_duration_ms=int(self.config.min_silence_duration * 1000),
+                speech_pad_ms=int(self.config.speech_pad * 1000),
+            )
+        except Exception as exc:  # pragma: no cover - optional dependency
+            self._load_error = f"ошибка работы Silero VAD: {exc}"
+            self.using_vac = False
+            return []
+
+        if not timestamps:
+            return []
+
+        chunks: List[np.ndarray] = []
+        channels = multi_window.shape[1]
+        for ts in timestamps:
+            start = max(int(ts.get("start", 0)), 0)
+            end = max(int(ts.get("end", len(multi_window))), 0)
+            end = min(end, len(multi_window))
+            if end <= start:
+                continue
+            segment = multi_window[start:end]
+            if channels == 1:
+                chunks.append(segment.copy())
+            else:
+                chunks.append(segment.copy())
+
+        return chunks
+
+    # ----------------------- Fallback path ----------------------------
+    def _push_without_vad(self, frame: np.ndarray) -> List[np.ndarray]:
+        now = time.time()
+
+        if self._overlap_tail is not None:
+            self._chunk_buffer = [self._overlap_tail.copy()]
+            self._chunk_samples = len(self._overlap_tail)
+            self._overlap_tail = None
+            self._chunk_start_time = self._chunk_start_time or now
+
+        if not self._chunk_buffer:
+            self._chunk_start_time = now
+
+        self._chunk_buffer.append(frame)
+        self._chunk_samples += len(frame)
+
+        target_samples = max(int(self.config.chunk_duration * self.config.samplerate), self.config.samplerate // 2)
+        duration_ready = False
+        if self._chunk_start_time is not None:
+            duration_ready = (now - self._chunk_start_time) >= self.config.chunk_duration
+
+        if self._chunk_samples < target_samples and not duration_ready:
+            return []
+
+        combined = np.concatenate(self._chunk_buffer, axis=0)
+        self._chunk_buffer = []
+        self._chunk_samples = 0
+        self._chunk_start_time = None
+
+        if self.config.overlap_ratio > 0 and combined.size:
+            overlap_samples = int(combined.shape[0] * self.config.overlap_ratio)
+            if overlap_samples > 0:
+                self._overlap_tail = combined[-overlap_samples:].copy()
+
+        return [combined]
+
+    # --------------------------- Utils --------------------------------
+    def _split_frame(self, frame: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        if frame.ndim == 1:
+            mono = frame.astype(np.float32, copy=False)
+            multi = mono[:, None]
+            return mono, multi
+
+        mono = frame.mean(axis=1).astype(np.float32, copy=False)
+        multi = frame.astype(np.float32, copy=False)
+        return mono, multi
+
+
+__all__ = ["VoiceActivityController", "VACConfig"]


### PR DESCRIPTION
## Summary
- add a voice activity controller module that wraps Silero VAD with an RMS fallback
- route streaming transcription through the VAC stage and extend the profile configuration
- expose CLI flags to enable/disable VAC and tune window parameters

## Testing
- PYTHONPATH=src pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6bc9fa00883209feece49e4bb4298