### PR TITLE
Add backend abstraction and simulation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,38 @@ python -m sts.cli --record --input-device "MacBook Pro Microphone" --output tran
 python -m sts.cli --system-audio --input-device "BlackHole 2ch" --output transcript.txt
 ```
 
+### Выбор бэкенда и управление кэшем
+
+CLI поддерживает несколько бэкендов распознавания, которые выбираются через флаг `--backend`:
+
+- `faster-whisper` — локальный инференс с fallback на `int8` и гибкой настройкой потоков.
+- `whisper-timestamped` — совместим с пакетом `whisper_timestamped`, если он установлен.
+- `openai-api` — обращается к облачному API OpenAI (требуется установленный пакет `openai` и ключ API).
+
+Чтобы переопределить каталог с локальными весами или кэшем, используйте флаги `--model-dir` и `--cache-dir`:
+
+```bash
+python -m sts.cli --input audio.wav --backend faster-whisper --model-dir ~/models --cache-dir ~/.cache/whisper
+```
+
+Если в указанном каталоге уже лежит распакованная модель (папка с весами), она будет использована без повторного скачивания.
+
+### Симуляция потоковой транскрибации
+
+Для отладки интерфейсов можно воспроизводить заранее записанные трассы потоковых событий. Формат трассы — JSONL, где каждая строка содержит поля `timestamp`, `text`, `language` и опционально `duration`.
+
+```bash
+python -m sts.cli --stream --simulate-trace traces/sample.jsonl --simulation-speed 2.0
+```
+
+Параметры симуляции:
+
+- `--simulation-speed` — ускорение или замедление (1.0 — реальное время).
+- `--simulation-loop` — зациклить воспроизведение до `Ctrl+C`.
+- `--simulation-warmup` — задержка перед стартом, полезно для подготовки UI.
+
+См. модуль `sts.transcriber.replay_stream_trace` для программного доступа к этим функциям, а также smoke-тест `tests/test_transcriber.py::ReplayTraceTests` для минимального примера трассы.
+
 ### Оптимизация под Mac M1 Pro
 
 - **CPU-инференс**: по умолчанию используется устройство `cpu`, что даёт стабильную работу без необходимости настраивать GPU.

--- a/src/sts/__init__.py
+++ b/src/sts/__init__.py
@@ -1,21 +1,27 @@
 """Speech-to-text utilities built around faster-whisper."""
 
 from .transcriber import (
-    capture_audio, 
-    load_model, 
-    transcribe_audio, 
-    extract_audio_from_video, 
+    capture_audio,
+    load_model,
+    load_transcription_backend,
+    transcribe_audio,
+    extract_audio_from_video,
     is_video_file,
     capture_system_audio,
     find_system_audio_devices,
     stream_transcribe,
     StreamTranscriber,
     get_best_stream_profile,
+    list_backend_names,
+    DEFAULT_BACKEND_NAME,
+    replay_stream_trace,
+    load_stream_trace,
 )
 
 __all__ = [
     "capture_audio",
     "load_model",
+    "load_transcription_backend",
     "transcribe_audio",
     "extract_audio_from_video",
     "is_video_file",
@@ -24,4 +30,8 @@ __all__ = [
     "stream_transcribe",
     "StreamTranscriber",
     "get_best_stream_profile",
+    "list_backend_names",
+    "DEFAULT_BACKEND_NAME",
+    "replay_stream_trace",
+    "load_stream_trace",
 ]

--- a/src/sts/cli.py
+++ b/src/sts/cli.py
@@ -11,8 +11,9 @@ from typing import Optional
 import sounddevice as sd
 
 from .transcriber import (
+    DEFAULT_BACKEND_NAME,
     capture_audio,
-    load_model,
+    load_transcription_backend,
     transcribe_audio,
     extract_audio_from_video,
     is_video_file,
@@ -20,6 +21,8 @@ from .transcriber import (
     find_system_audio_devices,
     stream_transcribe,
     get_best_stream_profile,
+    list_backend_names,
+    replay_stream_trace,
 )
 
 
@@ -39,6 +42,7 @@ def build_parser() -> argparse.ArgumentParser:
             "через оптимизированную сборку Whisper."
         )
     )
+    backend_choices = list_backend_names()
     source_group = parser.add_mutually_exclusive_group(required=False)
     source_group.add_argument(
         "--input",
@@ -69,6 +73,24 @@ def build_parser() -> argparse.ArgumentParser:
         "--model",
         default="small",
         help="Размер модели Whisper. small — оптимальный баланс качества и скорости для CPU и поддерживает многие языки.",
+    )
+    parser.add_argument(
+        "--backend",
+        default=DEFAULT_BACKEND_NAME,
+        choices=backend_choices,
+        help="Бэкенд распознавания (faster-whisper, whisper-timestamped, openai-api и др.)",
+    )
+    parser.add_argument(
+        "--model-dir",
+        type=Path,
+        default=None,
+        help="Каталог с локальными весами моделей (используется прежде всего для offline-бэкендов).",
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Каталог кэша для скачивания моделей (по умолчанию используется значение из бэкенда).",
     )
     parser.add_argument(
         "--device",
@@ -146,6 +168,32 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Отключить VAD-фильтр быстрее-шёпота (по умолчанию включён).",
     )
+    parser.add_argument(
+        "--simulate-trace",
+        type=Path,
+        default=None,
+        help=(
+            "Путь к JSONL-файлу с офлайн-трассой потоковой транскрибации. "
+            "Используйте совместно с --stream для воспроизведения результатов без модели."
+        ),
+    )
+    parser.add_argument(
+        "--simulation-speed",
+        type=float,
+        default=1.0,
+        help="Коэффициент ускорения при воспроизведении офлайн-трассы (1.0 = реальное время).",
+    )
+    parser.add_argument(
+        "--simulation-loop",
+        action="store_true",
+        help="Повторять воспроизведение трассы по кругу, пока не будет нажато Ctrl+C.",
+    )
+    parser.add_argument(
+        "--simulation-warmup",
+        type=float,
+        default=0.0,
+        help="Задержка перед началом воспроизведения трассы в секундах.",
+    )
     return parser
 
 
@@ -218,7 +266,10 @@ def main(argv: Optional[list[str]] = None) -> None:
     args = parser.parse_args(argv)
 
     _maybe_list_devices(args.list_devices)
-    
+
+    normalized_backend = args.backend.lower().replace("_", "-")
+    is_faster_whisper_backend = normalized_backend in {"faster-whisper", "fwhisper", "default"}
+
     # Проверяем, что выбран один из источников
     if not any([args.input, args.record, args.system_audio, args.web, args.stream]):
         parser.error("Необходимо выбрать один из: --input, --record, --system-audio, --web, или --stream")
@@ -234,7 +285,12 @@ def main(argv: Optional[list[str]] = None) -> None:
         requested_language = args.language.lower() if args.language else None
         model_name = args.model
 
-        if requested_language and requested_language != "en" and model_name.endswith(".en"):
+        if (
+            is_faster_whisper_backend
+            and requested_language
+            and requested_language != "en"
+            and model_name.endswith(".en")
+        ):
             multilingual_candidate = model_name[: -len(".en")]
             if multilingual_candidate:
                 print(
@@ -244,28 +300,46 @@ def main(argv: Optional[list[str]] = None) -> None:
                 )
                 model_name = multilingual_candidate
 
-        profile = get_best_stream_profile()
-        cpu_threads = args.cpu_threads if args.cpu_threads is not None else profile.cpu_threads
-
-        model = load_model(
-            model_name,
-            device=args.device,
-            compute_type=args.compute_type,
-            cpu_threads=cpu_threads,
-        )
-
         def print_result(result):
             print(f"[{result['language']}] {result['text']}")
             if args.output:
                 with open(args.output, 'a', encoding='utf-8') as f:
                     f.write(f"{result['text']} ")
 
+        if args.simulate_trace:
+            try:
+                replay_stream_trace(
+                    args.simulate_trace,
+                    callback=print_result,
+                    speed=args.simulation_speed,
+                    loop=args.simulation_loop,
+                    warmup=args.simulation_warmup,
+                )
+            except KeyboardInterrupt:
+                pass
+            return
+
+        profile = get_best_stream_profile()
+        cpu_threads = args.cpu_threads if args.cpu_threads is not None else profile.cpu_threads
+
+        backend = load_transcription_backend(
+            args.backend,
+            model_name,
+            device=args.device,
+            compute_type=args.compute_type,
+            cpu_threads=cpu_threads,
+            model_dir=args.model_dir,
+            cache_dir=args.cache_dir,
+        )
+
         stream_transcribe(
-            model=model,
+            backend,
             device=_parse_input_device(args.input_device),
+            samplerate=args.samplerate,
+            channels=args.channels,
             language=requested_language,
             profile=profile,
-            callback=print_result
+            callback=print_result,
         )
         return
 
@@ -274,7 +348,12 @@ def main(argv: Optional[list[str]] = None) -> None:
     requested_language = args.language.lower() if args.language else None
     model_name = args.model
 
-    if requested_language and requested_language != "en" and model_name.endswith(".en"):
+    if (
+        is_faster_whisper_backend
+        and requested_language
+        and requested_language != "en"
+        and model_name.endswith(".en")
+    ):
         multilingual_candidate = model_name[: -len(".en")]
         if multilingual_candidate:
             print(
@@ -293,14 +372,18 @@ def main(argv: Optional[list[str]] = None) -> None:
     try:
         audio_path, is_temp_file = _resolve_input_file(args)
 
-        model = load_model(
+        backend = load_transcription_backend(
+            args.backend,
             model_name,
             device=args.device,
             compute_type=args.compute_type,
             cpu_threads=args.cpu_threads,
+            model_dir=args.model_dir,
+            cache_dir=args.cache_dir,
         )
 
-        if requested_language and requested_language != "en" and not getattr(model, "is_multilingual", True):
+        handle = getattr(backend, "handle", None)
+        if requested_language and requested_language != "en" and not getattr(handle, "is_multilingual", True):
             print(
                 "Загруженная модель поддерживает только английский язык. Выберите многоязычную модель (например, small).",
                 file=sys.stderr,
@@ -308,7 +391,7 @@ def main(argv: Optional[list[str]] = None) -> None:
             raise SystemExit(1)
 
         result = transcribe_audio(
-            model,
+            backend,
             audio_path,
             beam_size=args.beam_size,
             language=requested_language,

--- a/src/sts/transcriber.py
+++ b/src/sts/transcriber.py
@@ -2,19 +2,43 @@
 
 from __future__ import annotations
 
+import json
 import math
-from collections import deque
 import queue
 import sys
+import tempfile
 import time
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Deque, List, Optional, Sequence, Set, Union
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+)
 
 import numpy as np
 import sounddevice as sd
 import soundfile as sf
 from faster_whisper import WhisperModel
+
+try:  # pragma: no cover - optional dependency
+    import whisper_timestamped as whisper_ts
+except ImportError:  # pragma: no cover - optional dependency
+    whisper_ts = None
+
+try:  # pragma: no cover - optional dependency
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - optional dependency
+    OpenAI = None
 
 try:
     import ffmpeg
@@ -66,6 +90,295 @@ class TranscriptionResult:
     segments: List[TranscriptionSegment]
     duration: float
     language: Optional[str]
+
+
+@dataclass(frozen=True)
+class BackendLoadOptions:
+    """Configuration used to initialize a transcription backend."""
+
+    model: str
+    device: str = "cpu"
+    compute_type: str = "auto"
+    cpu_threads: Optional[int] = None
+    model_dir: Optional[Path] = None
+    cache_dir: Optional[Path] = None
+    extra: Optional[Mapping[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class BackendSpec:
+    """Description and helpers for a particular transcription backend."""
+
+    name: str
+    aliases: tuple[str, ...]
+    loader: Callable[[BackendLoadOptions], Any]
+    transcribe: Callable[..., TranscriptionResult]
+    stream: Optional[Callable[..., None]] = None
+    description: str = ""
+
+    @property
+    def supports_streaming(self) -> bool:
+        return self.stream is not None
+
+
+@dataclass
+class LoadedBackend:
+    """Runtime object that wraps an initialized backend implementation."""
+
+    spec: BackendSpec
+    handle: Any
+    options: BackendLoadOptions
+
+    def transcribe(self, audio_source: Union[Path, np.ndarray], **kwargs: Any) -> TranscriptionResult:
+        return self.spec.transcribe(
+            self.handle,
+            audio_source,
+            backend_options=self.options,
+            **kwargs,
+        )
+
+    def stream(self, **kwargs: Any) -> None:
+        if not self.spec.supports_streaming:
+            raise RuntimeError(f"Бэкенд '{self.spec.name}' не поддерживает потоковую транскрибацию")
+        assert self.spec.stream is not None
+        self.spec.stream(self.handle, backend_options=self.options, **kwargs)
+
+
+_BACKEND_REGISTRY: Dict[str, BackendSpec] = {}
+_CANONICAL_BACKENDS: Dict[str, BackendSpec] = {}
+
+
+def register_backend(spec: BackendSpec) -> None:
+    """Register backend under its canonical name and aliases."""
+
+    canonical_key = spec.name.lower()
+    if canonical_key in _CANONICAL_BACKENDS:
+        raise ValueError(f"Бэкенд '{spec.name}' уже зарегистрирован")
+
+    _CANONICAL_BACKENDS[canonical_key] = spec
+    for alias in (spec.name, *spec.aliases):
+        _BACKEND_REGISTRY[alias.lower()] = spec
+
+
+def get_backend(name: str) -> BackendSpec:
+    try:
+        return _BACKEND_REGISTRY[name.lower()]
+    except KeyError as exc:
+        raise ValueError(f"Неизвестный бэкенд транскрибации: {name}") from exc
+
+
+def list_available_backends() -> List[BackendSpec]:
+    return sorted(_CANONICAL_BACKENDS.values(), key=lambda spec: spec.name)
+
+
+def list_backend_names() -> List[str]:
+    return [spec.name for spec in list_available_backends()]
+
+
+def load_transcription_backend(
+    backend: str,
+    model: str,
+    *,
+    device: str = "cpu",
+    compute_type: str = "auto",
+    cpu_threads: Optional[int] = None,
+    model_dir: Optional[Path] = None,
+    cache_dir: Optional[Path] = None,
+    extra: Optional[Mapping[str, Any]] = None,
+) -> LoadedBackend:
+    """Instantiate the requested backend and return a wrapper object."""
+
+    spec = get_backend(backend)
+    options = BackendLoadOptions(
+        model=model,
+        device=device,
+        compute_type=compute_type,
+        cpu_threads=cpu_threads,
+        model_dir=model_dir,
+        cache_dir=cache_dir,
+        extra=extra,
+    )
+    handle = spec.loader(options)
+    return LoadedBackend(spec=spec, handle=handle, options=options)
+
+
+def _load_faster_whisper_backend(options: BackendLoadOptions) -> WhisperModel:
+    return load_model(
+        options.model,
+        device=options.device,
+        compute_type=options.compute_type,
+        cpu_threads=options.cpu_threads,
+        model_dir=options.model_dir,
+        cache_dir=options.cache_dir,
+    )
+
+
+def _transcribe_with_faster_whisper_backend(
+    model: WhisperModel,
+    audio_source: Union[Path, np.ndarray],
+    *,
+    backend_options: BackendLoadOptions,
+    **kwargs: Any,
+) -> TranscriptionResult:
+    return _transcribe_with_faster_whisper(model, audio_source, **kwargs)
+
+
+def _stream_faster_whisper_backend(
+    model: WhisperModel,
+    *,
+    backend_options: BackendLoadOptions,
+    **kwargs: Any,
+) -> None:
+    _stream_with_faster_whisper(model, **kwargs)
+
+
+def _load_whisper_timestamped_backend(options: BackendLoadOptions) -> Any:
+    if whisper_ts is None:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "Пакет whisper_timestamped не установлен. Установите его командой 'pip install whisper-timestamped'."
+        )
+
+    model_path: Union[str, Path] = options.model
+    if options.model_dir is not None:
+        model_dir = Path(options.model_dir).expanduser().resolve()
+        candidate = model_dir / options.model
+        if candidate.exists():
+            model_path = candidate
+
+    return whisper_ts.load_model(str(model_path))
+
+
+def _transcribe_with_whisper_timestamped_backend(
+    model: Any,
+    audio_source: Union[Path, np.ndarray],
+    *,
+    backend_options: BackendLoadOptions,
+    language: Optional[str] = None,
+    **_: Any,
+) -> TranscriptionResult:
+    if whisper_ts is None:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "Пакет whisper_timestamped не установлен. Установите его командой 'pip install whisper-timestamped'."
+        )
+
+    if isinstance(audio_source, Path):
+        audio_input: Union[str, np.ndarray] = str(audio_source)
+    else:
+        audio_input = audio_source
+
+    result = whisper_ts.transcribe(model, audio_input, language=language)
+    raw_segments = result.get("segments", []) if isinstance(result, dict) else []
+
+    segments: List[TranscriptionSegment] = []
+    text_parts: List[str] = []
+
+    for segment in raw_segments:
+        start = float(segment.get("start", 0.0))
+        end = float(segment.get("end", start))
+        text = _strip_repeated_sequences(str(segment.get("text", "")).strip())
+        text_parts.append(text)
+        segments.append(TranscriptionSegment(start=start, end=end, text=text))
+
+    aggregated = _assemble_transcription(text_parts)
+    return TranscriptionResult(
+        text=aggregated,
+        segments=segments,
+        duration=float(result.get("duration", 0.0)) if isinstance(result, dict) else 0.0,
+        language=result.get("language") if isinstance(result, dict) else None,
+    )
+
+
+def _load_openai_backend(options: BackendLoadOptions) -> Any:
+    if OpenAI is None:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "Пакет openai не установлен. Установите его командой 'pip install openai'."
+        )
+
+    extra = dict(options.extra or {})
+    api_key = extra.get("api_key")
+    if api_key:
+        return OpenAI(api_key=api_key)
+    return OpenAI()
+
+
+def _transcribe_with_openai_backend(
+    client: Any,
+    audio_source: Union[Path, np.ndarray],
+    *,
+    backend_options: BackendLoadOptions,
+    language: Optional[str] = None,
+    samplerate: int = 16_000,
+    **_: Any,
+) -> TranscriptionResult:
+    if OpenAI is None:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "Пакет openai не установлен. Установите его командой 'pip install openai'."
+        )
+
+    cleanup: Optional[Path] = None
+    if isinstance(audio_source, Path):
+        file_path = audio_source
+    else:
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp.close()
+        file_path = Path(tmp.name)
+        cleanup = file_path
+        sf.write(str(file_path), audio_source, samplerate)
+
+    try:
+        with file_path.open("rb") as fh:
+            response = client.audio.transcriptions.create(
+                model=backend_options.model,
+                file=fh,
+                language=language,
+            )
+    finally:
+        if cleanup and cleanup.exists():
+            cleanup.unlink()
+
+    text = getattr(response, "text", None) or response.get("text", "")
+    return TranscriptionResult(
+        text=text,
+        segments=[TranscriptionSegment(start=0.0, end=0.0, text=text)],
+        duration=0.0,
+        language=language,
+    )
+
+
+DEFAULT_BACKEND_NAME = "faster-whisper"
+
+register_backend(
+    BackendSpec(
+        name=DEFAULT_BACKEND_NAME,
+        aliases=("faster_whisper", "fwhisper", "default"),
+        loader=_load_faster_whisper_backend,
+        transcribe=_transcribe_with_faster_whisper_backend,
+        stream=_stream_faster_whisper_backend,
+        description="Локальный инференс через faster-whisper",
+    )
+)
+
+register_backend(
+    BackendSpec(
+        name="whisper-timestamped",
+        aliases=("timestamped", "wt"),
+        loader=_load_whisper_timestamped_backend,
+        transcribe=_transcribe_with_whisper_timestamped_backend,
+        stream=None,
+        description="Бэкенд whisper_timestamped для получения детальных таймкодов",
+    )
+)
+
+register_backend(
+    BackendSpec(
+        name="openai-api",
+        aliases=("openai", "api"),
+        loader=_load_openai_backend,
+        transcribe=_transcribe_with_openai_backend,
+        stream=None,
+        description="Облачный API OpenAI Whisper/Audio",
+    )
+)
 
 
 def _calculate_overlap(previous: str, current: str, *, max_overlap_chars: int = 160) -> int:
@@ -294,6 +607,8 @@ def load_model(
     device: str = "cpu",
     compute_type: str = "auto",
     cpu_threads: Optional[int] = None,
+    model_dir: Optional[Path] = None,
+    cache_dir: Optional[Path] = None,
 ) -> WhisperModel:
     """Load an optimized Whisper model via faster-whisper.
 
@@ -323,9 +638,28 @@ def load_model(
             unique_candidates.append(candidate)
             seen.add(candidate)
 
+    model_identifier: Union[str, Path] = model_size
+
+    download_root: Optional[Path] = None
+    if model_dir is not None:
+        model_dir = Path(model_dir).expanduser().resolve()
+        candidate = model_dir / model_size
+        if candidate.exists():
+            model_identifier = candidate
+        else:
+            download_root = model_dir
+
+    if cache_dir is not None:
+        cache_path = Path(cache_dir).expanduser().resolve()
+        download_root = download_root or cache_path
+
     kwargs = {
         "device": device,
     }
+
+    if download_root is not None:
+        download_root.mkdir(parents=True, exist_ok=True)
+        kwargs["download_root"] = str(download_root)
 
     if cpu_threads is not None:
         # The faster-whisper bindings expose thread configuration via num_workers
@@ -337,7 +671,7 @@ def load_model(
     for candidate in unique_candidates:
         try:
             return WhisperModel(
-                model_size,
+                str(model_identifier),
                 compute_type=candidate,
                 **kwargs,
             )
@@ -370,7 +704,7 @@ def load_model(
     raise RuntimeError("Не удалось загрузить модель Whisper: отсутствуют варианты compute_type")
 
 
-def transcribe_audio(
+def _transcribe_with_faster_whisper(
     model: WhisperModel,
     audio_source: Union[Path, np.ndarray],
     *,
@@ -432,6 +766,19 @@ def transcribe_audio(
         duration=getattr(info, "duration", 0.0),
         language=getattr(info, "language", None),
     )
+
+
+def transcribe_audio(
+    model: Union[WhisperModel, LoadedBackend],
+    audio_source: Union[Path, np.ndarray],
+    **kwargs: Any,
+) -> TranscriptionResult:
+    """Transcribe audio using either a direct model instance or a backend wrapper."""
+
+    if isinstance(model, LoadedBackend):
+        return model.transcribe(audio_source, **kwargs)
+
+    return _transcribe_with_faster_whisper(model, audio_source, **kwargs)
 
 
 def extract_audio_from_video(
@@ -820,7 +1167,7 @@ class StreamTranscriber:
         return self.recording
 
 
-def stream_transcribe(
+def _stream_with_faster_whisper(
     model: WhisperModel,
     device: Optional[int | str] = None,
     samplerate: int = 16_000,
@@ -857,3 +1204,119 @@ def stream_transcribe(
             time.sleep(0.1)
     except KeyboardInterrupt:
         transcriber.stop()
+
+
+def stream_transcribe(
+    model: Union[WhisperModel, LoadedBackend],
+    device: Optional[int | str] = None,
+    samplerate: int = 16_000,
+    channels: int = 2,
+    chunk_duration: Optional[float] = None,
+    language: Optional[str] = None,
+    profile: Optional[StreamProfile] = None,
+    callback=None,
+) -> None:
+    """Public wrapper that supports both direct models and registered backends."""
+
+    if isinstance(model, LoadedBackend):
+        model.stream(
+            device=device,
+            samplerate=samplerate,
+            channels=channels,
+            chunk_duration=chunk_duration,
+            language=language,
+            profile=profile,
+            callback=callback,
+        )
+        return
+
+    _stream_with_faster_whisper(
+        model,
+        device=device,
+        samplerate=samplerate,
+        channels=channels,
+        chunk_duration=chunk_duration,
+        language=language,
+        profile=profile,
+        callback=callback,
+    )
+
+
+@dataclass
+class StreamTraceEvent:
+    """Single entry inside an offline simulation trace."""
+
+    timestamp: float
+    text: str
+    language: Optional[str] = None
+    duration: Optional[float] = None
+
+
+def load_stream_trace(trace_path: Path) -> List[StreamTraceEvent]:
+    """Load a JSONL trace produced by a previous streaming session."""
+
+    events: List[StreamTraceEvent] = []
+    with Path(trace_path).expanduser().open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            events.append(
+                StreamTraceEvent(
+                    timestamp=float(payload.get("timestamp", 0.0)),
+                    text=str(payload.get("text", "")),
+                    language=payload.get("language"),
+                    duration=(
+                        float(payload.get("duration"))
+                        if payload.get("duration") is not None
+                        else None
+                    ),
+                )
+            )
+
+    return events
+
+
+def replay_stream_trace(
+    trace_path: Path,
+    callback: Callable[[Dict[str, Any]], None],
+    *,
+    speed: float = 1.0,
+    loop: bool = False,
+    warmup: float = 0.0,
+) -> None:
+    """Replay a previously recorded streaming trace."""
+
+    if speed <= 0:
+        raise ValueError("Коэффициент speed должен быть больше нуля")
+
+    events = load_stream_trace(trace_path)
+    if not events:
+        raise ValueError("Трасса пуста — нечего воспроизводить")
+
+    baseline = events[0].timestamp
+    normalized = [StreamTraceEvent(timestamp=e.timestamp - baseline, text=e.text, language=e.language, duration=e.duration) for e in events]
+
+    while True:
+        start_wall = time.time() + warmup
+        for event in normalized:
+            target = event.timestamp / speed
+            while True:
+                elapsed = time.time() - start_wall
+                remaining = target - elapsed
+                if remaining <= 0:
+                    break
+                time.sleep(min(remaining, 0.05))
+
+            payload: Dict[str, Any] = {
+                "text": event.text,
+                "language": event.language,
+                "timestamp": event.timestamp,
+            }
+            if event.duration is not None:
+                payload["duration"] = event.duration
+            callback(payload)
+
+        if not loop:
+            break

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -1,7 +1,16 @@
+"""Lightweight tests for backend selection and simulation helpers."""
+
+from __future__ import annotations
+
+import json
 import sys
+import tempfile
 import types
 import unittest
+from pathlib import Path
 from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 
 def _install_stub_module(name: str, **attrs):
@@ -20,13 +29,19 @@ _install_stub_module(
     ndarray=type("ndarray", (), {}),
     float32=float,
     array=lambda *args, **kwargs: None,
-    max=lambda *args, **kwargs: 0,
+    max=max,
     abs=abs,
     concatenate=lambda *args, **kwargs: None,
     mean=lambda *args, **kwargs: 0.0,
 )
-_install_stub_module("sounddevice")
-_install_stub_module("soundfile")
+_install_stub_module(
+    "sounddevice",
+    query_devices=lambda: [],
+)
+_install_stub_module(
+    "soundfile",
+    write=lambda *args, **kwargs: None,
+)
 _install_stub_module("ffmpeg")
 _install_stub_module("faster_whisper", WhisperModel=object)
 
@@ -35,7 +50,6 @@ from sts import transcriber
 
 class DummyModel:
     def __init__(self, model_size: str, *, compute_type: str, **kwargs):
-        # Simulate backend rejecting int16 compute type
         if compute_type == "int16":
             raise ValueError(
                 "Requested int16 compute type, but the target device or backend do not support efficient int16 computation."
@@ -43,16 +57,68 @@ class DummyModel:
         self.model_size = model_size
         self.compute_type = compute_type
         self.kwargs = kwargs
+        self.is_multilingual = True
+
+    def transcribe(self, *args, **kwargs):  # pragma: no cover - behaviour covered through wrapper
+        segment = types.SimpleNamespace(start=0.0, end=1.0, text="hello")
+        info = types.SimpleNamespace(duration=1.0, language="en")
+        return [segment], info
 
 
 class LoadModelFallbackTests(unittest.TestCase):
     def test_fallback_to_int8_when_int16_unavailable(self):
         with patch.object(transcriber, "WhisperModel", DummyModel):
-            model = transcriber.load_model("tiny", device="cpu", compute_type="auto")
+            backend = transcriber.load_transcription_backend(
+                "faster-whisper",
+                "tiny",
+                device="cpu",
+                compute_type="auto",
+            )
 
-        self.assertIsInstance(model, DummyModel)
-        self.assertEqual(model.compute_type, "int8")
+        self.assertIsInstance(backend.handle, DummyModel)
+        self.assertEqual(backend.handle.compute_type, "int8")
+
+    def test_transcribe_audio_delegates_to_backend(self):
+        with patch.object(transcriber, "WhisperModel", DummyModel):
+            backend = transcriber.load_transcription_backend(
+                "faster-whisper",
+                "tiny",
+                device="cpu",
+                compute_type="int8",
+            )
+
+        result = transcriber.transcribe_audio(backend, Path("dummy.wav"))
+        self.assertEqual(result.text, "hello")
+        self.assertEqual(len(result.segments), 1)
+
+
+class ReplayTraceTests(unittest.TestCase):
+    def test_replay_stream_trace_invokes_callback(self):
+        events = [
+            {"timestamp": 0.0, "text": "one", "language": "en"},
+            {"timestamp": 0.5, "text": "two", "language": "en", "duration": 0.4},
+        ]
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as handle:
+            path = Path(handle.name)
+            for event in events:
+                handle.write(json.dumps(event) + "\n")
+
+        received: list[dict[str, str]] = []
+
+        try:
+            transcriber.replay_stream_trace(
+                path,
+                callback=lambda payload: received.append(payload),
+                speed=50.0,  # ускоряем во избежание задержек
+            )
+        finally:
+            path.unlink(missing_ok=True)
+
+        self.assertEqual(len(received), 2)
+        self.assertEqual(received[0]["text"], "one")
+        self.assertEqual(received[1]["text"], "two")
 
 
 if __name__ == "__main__":  # pragma: no cover - test entry point
     unittest.main()
+


### PR DESCRIPTION
## Summary
- introduce a backend registry for faster-whisper, whisper-timestamped, and OpenAI, including helpers to load and stream via a common interface
- extend the CLI with backend selection, custom model/cache directories, and offline streaming simulation controls
- document the new modes and add smoke tests covering backend fallback and JSONL trace replay

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d6bcb2740483208d562be0075bff5d